### PR TITLE
bugfix: switch to local.properties for api key storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,3 @@
 .externalNativeBuild
 .cxx
 local.properties
-api_keys.properties

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@
 .externalNativeBuild
 .cxx
 local.properties
-gradle.properties
+api_keys.properties

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,7 +17,7 @@ android {
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
-        buildConfigField("String", "SPOTIFY_CLIENT_ID", SPOTIFY_CLIENT_ID)
+        buildConfigField("String", "SPOTIFY_CLIENT_ID", "\"${System.getenv("SPOTIFY_API_KEY")}\"")
     }
 
     buildFeatures {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,3 @@
 org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 android.useAndroidX=true
 android.nonTransitiveRClass=true
-
-# API SECRETS
-SPOTIFY_CLIENT_ID=


### PR DESCRIPTION
The api keys should now be stored in the local.properties file; fixes an issue with gradle.properties being tracked by git.